### PR TITLE
Fix TS @theme path.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,12 +8,11 @@
         "alias": [
           { "@shared-components": "./src/shared/components" },
           { "@shared-constants": "./src/shared/constants" },
-          { "@shared-theme": "./src/shared/theme" },
           { "@font-size": "./src/shared/theme/font-size" },
           { "@api": "./src/services/api/index" },
           { "@fonts": "./src/shared/theme/fonts/index" },
           { "@colors": "./src/shared/theme/colors" },
-          { "@theme": "./src/shared/theme/index" },
+          { "@theme": "./src/shared/theme" },
           { "@models": "./src/services/models" },
           { "@services": "./src/services" },
           { "@screens": "./src/screens" },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,7 +34,7 @@
       "@api": ["./services/api/index"],
       "@fonts": ["./shared/theme/fonts/index"],
       "@colors": ["./shared/theme/colors"],
-      "@theme": ["./shared/theme/*"],
+      "@theme/*": ["./shared/theme/*"],
       "@services/*": ["./services/*"],
       "@screens/*": ["./screens/*"],
       "@utils": ["./utils/"],


### PR DESCRIPTION
I think this is the intention in this file, so that you _could_ import the colours like `@theme/colors`.

Without the asterisk, TypeScript gets confused and can't resolve the import, or tries to import like:

```tsx
import fonts from "@theme";
``` 

(this is with auto import on VS Code)